### PR TITLE
Fix how the URL field is hidden

### DIFF
--- a/web/modules/custom/pl_drupal_forge/src/Form/PlDrupalForgeSettingsForm.php
+++ b/web/modules/custom/pl_drupal_forge/src/Form/PlDrupalForgeSettingsForm.php
@@ -32,7 +32,7 @@ class PlDrupalForgeSettingsForm extends ConfigFormBase {
 
     $form['show_url'] = [
       '#type' => 'checkbox',
-      '#title' => $this->t('Show URL'),
+      '#title' => $this->t('Show URL field'),
       '#default_value' => $config->get('show_url'),
       '#description' => $this->t('Check this box to show the URL field on the test runner page. It will be hidden by default.'),
     ];

--- a/web/modules/custom/pl_drupal_forge/templates/start-page-template.html.twig
+++ b/web/modules/custom/pl_drupal_forge/templates/start-page-template.html.twig
@@ -2,12 +2,10 @@
 
 <div class="pl-card pl-div--width-600">
   <form id="test-runner-form" class="pl-form">
-    {% if show_url %}
-      <div class="pl-form-item">
-        <label for="input-url" class="pl-form-item__label">URL</label>
-        <input id="input-url" class="pl-form-item__input" type="text" name="url" value="{{ base_url }}">
-      </div>
-    {% endif %}
+    <div class="pl-form-item  {% if not show_url %}visually-hidden{% endif %}">
+      <label for="input-url" class="pl-form-item__label">URL</label>
+      <input id="input-url" class="pl-form-item__input" type="text" name="url" value="{{ base_url }}">
+    </div>
     <div class="pl-form-item">
       <label for="tags" class="pl-form-item__label">Tags</label>
       <select id="tags" class="pl-form-item__select js-multiselect" name="tag" multiple="multiple">


### PR DESCRIPTION
Make url field visually hidden if `show_url` is set. 